### PR TITLE
README: Fixing voxelcss.js references

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,10 +9,10 @@ The goal of this project is to provide a lightweight 3D CSS library with very si
 
 ### Usage ###
 
-Download the [minified library](./dist/voxel.js) and [css file](./dist/voxel.css) and include both in your html.
+Download the [minified library](./dist/voxelcss.js) and [css file](./dist/voxel.css) and include both in your html.
 
 ```html
-<script src="js/voxel.js"></script>
+<script src="js/voxelcss.js"></script>
 <link rel='stylesheet' href="css/voxel.css"></link>
 ```
 
@@ -29,14 +29,14 @@ This code creates a scene, a savable world, and an editor that allow you to imme
     scene = new voxelcss.Scene();
     scene.rotate(-Math.PI / 8, Math.PI / 4, 0);
     scene.attach(document.body);
-    
+
     var lightSource = new voxelcss.LightSource(300, 300, 300, 750, 0.3, 1);
     scene.addLightSource(lightSource);
 
     world = new voxelcss.World(scene);
     editor = new voxelcss.Editor(world);
     editor.enableAutoSave();
-    
+
     editor.load();
     if(world.getVoxels().length === 0)
       editor.add(new voxelcss.Voxel(0, 0, 0, 100, {

--- a/readme.md
+++ b/readme.md
@@ -26,22 +26,22 @@ This code creates a scene, a savable world, and an editor that allow you to imme
 	init();
 
 	function init() {
-    scene = new voxelcss.Scene();
-    scene.rotate(-Math.PI / 8, Math.PI / 4, 0);
-    scene.attach(document.body);
+	scene = new voxelcss.Scene();
+	scene.rotate(-Math.PI / 8, Math.PI / 4, 0);
+	scene.attach(document.body);
 
-    var lightSource = new voxelcss.LightSource(300, 300, 300, 750, 0.3, 1);
-    scene.addLightSource(lightSource);
+	var lightSource = new voxelcss.LightSource(300, 300, 300, 750, 0.3, 1);
+	scene.addLightSource(lightSource);
 
-    world = new voxelcss.World(scene);
-    editor = new voxelcss.Editor(world);
-    editor.enableAutoSave();
+	world = new voxelcss.World(scene);
+	editor = new voxelcss.Editor(world);
+	editor.enableAutoSave();
 
-    editor.load();
-    if(world.getVoxels().length === 0)
-      editor.add(new voxelcss.Voxel(0, 0, 0, 100, {
-        mesh: voxelcss.Meshes.grass
-      }));
+	editor.load();
+	if(world.getVoxels().length === 0)
+	  editor.add(new voxelcss.Voxel(0, 0, 0, 100, {
+		mesh: voxelcss.Meshes.grass
+	  }));
 	}
 
 </script>


### PR DESCRIPTION
Also unifies the tabs/spaces usage in the code snippet.

Test:
1. On the main page of the repository, the README render should have `minified library` linking to the dist JS file.
2. The code snippet should references `js/voxelcss.js`
