### PR TITLE
correcting mistype

### DIFF
--- a/docs/Core/Scene.md
+++ b/docs/Core/Scene.md
@@ -151,7 +151,7 @@ zoom — New zoom offset.
 
 Offsets the zoom.
 
-`setSoom(soom)`
+`setZoom(zoom)`
 
 zoom — New zoom value.
 


### PR DESCRIPTION
Documentation on Scene. Line 154 there was "setSoom" method, but i believe it should be "setZoom".
