### PR TITLE
Apply fix to removeFromScene, so voxels can be removed.

### DIFF
--- a/src/core/Voxel.js
+++ b/src/core/Voxel.js
@@ -85,7 +85,7 @@
     }
     function RemoveFromScene(){
       if(parentScene === undefined) return;
-      parentScene.removeChild(cubeElement);
+      parentScene.remove(self);
     }
     function SetParentScene(scene){
       parentScene = scene;


### PR DESCRIPTION
`Voxel.removeFromScene(scene)` wasn't working because `removeChild` is not an existing method on the `scene` object. This throw errors when trying to use the method (see http://jsfiddle.net/rL70w9hd/).

The scene already has an `add` and `remove` method for this, and we can use them in [the same way that `AppendToScene` does](https://github.com/HunterLarco/voxel.css/blob/f2fed30043ebbece34d3ea50b347f36506dac39b/src/core/Voxel.js#L361). Pass the voxel itself to the remove function on the parent scene.

I'd include a test but I didn't see a test suite in the repo.
